### PR TITLE
[FIX] Revert to older JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM openjdk:8u121-alpine
 MAINTAINER LasLabs Inc <support@laslabs.com>
 
 ARG JIRA_VERSION=7.3.8


### PR DESCRIPTION
* Newer JDK image fontmanger symbols are broken due to change in Alpine 3.6. Will need to revert this when 3.6.3 comes out & is linked in the jdk.
  * https://bugs.alpinelinux.org/issues/7372